### PR TITLE
use hasMethod instead of method_exists

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -98,7 +98,7 @@ class Lumberjack extends Hierarchy {
 	 * @return string
 	 */
 	protected function getLumberjackTitle() {
-		if(method_exists($this->owner, 'getLumberjackTitle')) {
+		if($this->owner->hasMethod('getLumberjackTitle')) {
 			return $this->owner->getLumberjackTitle();
 		}
 		return _t("Lumberjack.TabTitle", "Child Pages");
@@ -111,7 +111,7 @@ class Lumberjack extends Hierarchy {
 	 * @return GridFieldConfig
 	 */
 	protected function getLumberjackGridFieldConfig() {
-		if(method_exists($this->owner, 'getLumberjackGridFieldConfig')) {
+		if($this->owner->hasMethod('getLumberjackGridFieldConfig')) {
 			return $this->owner->getLumberjackGridFieldConfig();
 		}
 		return GridFieldConfig_Lumberjack::create();


### PR DESCRIPTION
Allows these methods to be defined on the owner's SiteTreeExtension classes