### PR TITLE
filter hide_ancestor hidden page types from dropdown

### DIFF
--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -24,6 +24,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 			return array();
 		}
 
+		$nonHiddenPageTypes = SiteTree::page_type_classes();
 		$allowedChildren = $parent->allowedChildren();
 		$children = array();
 		foreach($allowedChildren as $class) {
@@ -32,7 +33,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 				// Note: Second argument to SiteTree::canCreate will support inherited permissions
 				// post 3.1.12, and will default to the old permission model in 3.1.11 or below
 				// See http://docs.silverstripe.org/en/changelogs/3.1.11
-				if($instance->canCreate(null, array('Parent' => $parent))) {
+				if($instance->canCreate(null, array('Parent' => $parent)) && in_array($class, $nonHiddenPageTypes)) {
 					$children[$class] = $instance->i18n_singular_name();
 				}
 			}


### PR DESCRIPTION
Pages that are hidden ancestors via $hide_ancestor should not show in GridFieldSiteTreeAddNewButton dropdown field
![screen shot 2015-11-04 at 7 46 20 pm](https://cloud.githubusercontent.com/assets/1166136/10931522/ddd6a064-832c-11e5-9073-35ac852372b3.png)
 