### PR TITLE
Ability to set child ClassName for Gridfield

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -37,7 +37,8 @@ class Lumberjack extends SiteTreeExtension {
 	public function updateCMSFields(FieldList $fields) {
 		$excluded = $this->owner->getExcludedSiteTreeClassNames();
 		if(!empty($excluded)) {
-			$pages = SiteTree::get()->filter(array(
+			$childClassName = $this->getChildClassName();
+			$pages = $childClassName::get()->filter(array(
 				'ParentID' => $this->owner->ID,
 				'ClassName' => $excluded
 			));
@@ -47,7 +48,6 @@ class Lumberjack extends SiteTreeExtension {
 				$pages,
 				$this->getLumberjackGridFieldConfig()
 			);
-
 			$tab = new Tab('ChildPages', $this->getLumberjackTitle(), $gridField);
 			$fields->insertAfter($tab, 'Main');
 		}
@@ -145,6 +145,22 @@ class Lumberjack extends SiteTreeExtension {
 		$controller = Controller::curr();
 		return $controller instanceof LeftAndMain
 			&& in_array($controller->getAction(), array("treeview", "listview", "getsubtree"));
+	}
+
+	/**
+	 * Checks config for a specified child_classname on the class extending Lumberjack.
+	 * Uses SiteTree if none found in config.
+	 *
+	 * @return string
+	 */
+	protected function getChildClassName() {
+		$childClassName = "SiteTree";
+		if ($childClassNameConfig = Injector::inst()->create($this->owner->ClassName)->config()->child_classname) {
+			if (class_exists($childClassNameConfig)) {
+				$childClassName = $childClassNameConfig;
+			}
+		}
+		return $childClassName;
 	}
 
 }


### PR DESCRIPTION
Developer can add a config option to use a specific child classname in the gridfield, rather than just SiteTree. 
This allows the gridfield to make use of the child class's `$default_sort` - as we know we only have a single class in GridField.
If we want to manage multiple classes, we skip the $child_classname and the GridField will render children of type SiteTree (as before).

This has many advantages:
* `$default_sort` of child class is picked up
* `GridFieldSortableHeader` will work with all variables of the child class
* `GridFieldFilterHeader`will work with all variables of the child class

Add the $default_child value via `config.yml`:

```yml
NewsHolder:
  extensions:
    - Lumberjack
  child_classname: 'NewsPage'
```
or via static variable inside the extended Class:

```php
class NewsHolder extends Page {
  private static $extensions = array('Lumberjack');
  private static $child_classname = 'NewsPage'
}
```

Credits to purplespider who developed this addition: https://github.com/micmania1/silverstripe-lumberjack/pull/16