### PR TITLE
Ability to set child ClassName for Gridfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ the `SiteTree` or `Page` class.
 	BlogEntry:
 	  show_in_sitetree: false
 	
+### Sorting and Filtering
 
+By default all children in Lumberjack GridField are sorted by SiteTree default `Sort` and can be filtered by their `Title`. This is restrictive but neccessary because there can be multiple different child classes and these are the values they all have in common.
+
+If you are only using one single child class in a Lumberjack Gridfield you can overcome this restriction by setting the `$child classname` to the class extending Lumberjack via config.
+This will enable the following functionality:
+* `$default_sort` of child class is picked up
+* `GridFieldSortableHeader` will work with all variables of the child class
+* `GridFieldFilterHeader`will work with all variables of the child class
+
+Add the `$child_classname` value to the class extending Lumberjack via `config.yml`:
+
+```yml
+NewsHolder:
+  extensions:
+    - Lumberjack
+  child_classname: 'NewsPage'
+```
+or via static variable inside the extended Class:
+
+```php
+class NewsHolder extends Page {
+  private static $extensions = array('Lumberjack');
+  private static $child_classname = 'NewsPage'
+}
+```
 
 

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -155,7 +155,7 @@ class Lumberjack extends SiteTreeExtension {
 	 */
 	protected function getChildClassName() {
 		$childClassName = "SiteTree";
-		if ($childClassNameConfig = Injector::inst()->create($this->owner->ClassName)->config()->child_classname) {
+		if ($childClassNameConfig = Config::inst()->get($this->owner->ClassName, 'child_classname')) {
 			if (class_exists($childClassNameConfig)) {
 				$childClassName = $childClassNameConfig;
 			}


### PR DESCRIPTION
Developer can add a config option to use a specific child classname in the gridfield, rather than just SiteTree. 
This allows the gridfield to make use of the child class's `$default_sort` - as we know we only have a single class in GridField.
If we want to manage multiple classes, we skip the $child_classname and the GridField will render children of type SiteTree (as before).

This has many advantages:
* `$default_sort` of child class is picked up
* `GridFieldSortableHeader` will work with all variables of the child class
* `GridFieldFilterHeader`will work with all variables of the child class

Add the `$child_classname` value to the class extending Lumberjack via `config.yml`:

```yml
NewsHolder:
  extensions:
    - Lumberjack
  child_classname: 'NewsPage'
```
or via static variable inside the extended Class:

```php
class NewsHolder extends Page {
  private static $extensions = array('Lumberjack');
  private static $child_classname = 'NewsPage'
}
```
Added documentation for this functionality in README.md

Credits to purplespider who developed this addition: https://github.com/micmania1/silverstripe-lumberjack/pull/16

