### PR TITLE
Fix CI by explicitly declaring both CMS and Framework dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
 	"description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
 	"type": "silverstripe-module",
 	"require": {
-		"silverstripe/cms": ">=3.1.0"
+		"silverstripe/framework": "^3.1",
+		"silverstripe/cms": "^3.1"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"


### PR DESCRIPTION
This locks the release to the same major release of framework only - Partially reverts a prior change to the composer dependencies.

Previously CI for CORE_RELEASE=3 had trouble installing in travis.