### PR TITLE
Optionally keep pages in the site tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,13 @@ the `SiteTree` or `Page` class.
 	
 
 
+It is possible to keep the page in the site tree and display it in Lumberjack's gridfield using the `show_in_lumberjack` config option.
 
+    :::yaml
+
+    BlogHolder:
+      extensions:
+        - 'Lumberjack'
+
+    BlogEntry:
+      show_in_lumberjack: true

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -16,14 +16,15 @@ class Lumberjack extends SiteTreeExtension
     /**
      * Loops through subclasses of the owner (intended to be SiteTree) and checks if they've been hidden.
      *
+     * @var bool $allowSiteTreeVisibility       whether to allow both gridfield and site tree visibility
      * @return array
      **/
-    public function getExcludedSiteTreeClassNames()
+    public function getExcludedSiteTreeClassNames($allowSiteTreeVisibility = false)
     {
         $classes = array();
         $siteTreeClasses = $this->owner->allowedChildren();
         foreach ($siteTreeClasses as $class) {
-            if (Config::inst()->get($class, 'show_in_sitetree') === false) {
+            if ((Config::inst()->get($class, 'show_in_sitetree') === false) || ($allowSiteTreeVisibility && Config::inst()->get($class, 'show_in_lumberjack'))) {
                 $classes[$class] = $class;
             }
         }
@@ -38,7 +39,7 @@ class Lumberjack extends SiteTreeExtension
      */
     public function updateCMSFields(FieldList $fields)
     {
-        $excluded = $this->owner->getExcludedSiteTreeClassNames();
+        $excluded = $this->owner->getExcludedSiteTreeClassNames(true);
         if (!empty($excluded)) {
             $pages = $this->getLumberjackPagesForGridfield($excluded);
             $gridField = new GridField(


### PR DESCRIPTION
Enable Lumberjack to display the child pages in both places, sitetree and the gridfield, if needed.

This solves #39.
