### PR TITLE
Cast the type of the config into a bool

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -23,7 +23,7 @@ class Lumberjack extends SiteTreeExtension
         $classes = array();
         $siteTreeClasses = $this->owner->allowedChildren();
         foreach ($siteTreeClasses as $class) {
-            if (Config::inst()->get($class, 'show_in_sitetree') === false) {
+            if (!Config::inst()->get($class, 'show_in_sitetree')) {
                 $classes[$class] = $class;
             }
         }

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -30,7 +30,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
         $allowedChildren = $parent->allowedChildren();
         $children = array();
         foreach ($allowedChildren as $class) {
-            if (Config::inst()->get($class, "show_in_sitetree") === false) {
+            if (!Config::inst()->get($class, "show_in_sitetree")) {
                 $instance = Injector::inst()->get($class);
                 // Note: Second argument to SiteTree::canCreate will support inherited permissions
                 // post 3.1.12, and will default to the old permission model in 3.1.11 or below


### PR DESCRIPTION
The config doesn't always get the config var as an boolean.
For example if `show_in_sitetree` is set to `false` the config could also return a empty value.
By adding the typecasting these empty values also get trough absolute false check.