### PR TITLE
getLumberjackTitle check extensions for definition

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -119,7 +119,7 @@ class Lumberjack extends SiteTreeExtension
      */
     protected function getLumberjackTitle()
     {
-        if (method_exists($this->owner, 'getLumberjackTitle')) {
+        if ($this->owner->hasMethod('getLumberjackTitle')) {
             return $this->owner->getLumberjackTitle();
         }
         return _t("Lumberjack.TabTitle", "Child Pages");


### PR DESCRIPTION
A getLumberjackTitle method implemented on an Extension of the class being lumberjacked would not be picked up with `method_exists`.