### PR TITLE
FIX only exclude SiteTree subclasses if there are any set.

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -71,14 +71,22 @@ class Lumberjack extends SiteTreeExtension
             $staged = $staged->filter('ShowInMenus', 1);
         }
         $this->owner->extend("augmentStageChildren", $staged, $showAll);
-
-        if ($this->shouldFilter()) {
-            // Filter the SiteTree
-            return $staged->exclude("ClassName", $this->owner->getExcludedSiteTreeClassNames());
-        }
+        $this->excludeSiteTreeClassNames($staged);
         return $staged;
     }
 
+    /**
+     * Excludes any hidden owner subclasses
+     * @param DataList $list
+     */
+    public function excludeSiteTreeClassNames($list)
+    {
+        $classNames = $this->owner->getExcludedSiteTreeClassNames();
+        if ($this->shouldFilter() && count($classNames)) {
+            // Filter the SiteTree
+            $list->exclude('ClassName', $classNames);
+        }
+    }
 
     /**
      * Augments (@link Hierarchy::liveChildren()} by hiding excluded child classnames
@@ -102,11 +110,8 @@ class Lumberjack extends SiteTreeExtension
         if (!$showAll) {
             $children = $children->filter('ShowInMenus', 1);
         }
+        $this->excludeSiteTreeClassNames($children);
 
-        if ($this->shouldFilter()) {
-            // Filter the SiteTree
-            return $children->exclude("ClassName", $this->owner->getExcludedSiteTreeClassNames());
-        }
         return $children;
     }
 

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -79,7 +79,7 @@ class Lumberjack extends SiteTreeExtension
      * Excludes any hidden owner subclasses
      * @param DataList $list
      */
-    public function excludeSiteTreeClassNames($list)
+    protected function excludeSiteTreeClassNames($list)
     {
         $classNames = $this->owner->getExcludedSiteTreeClassNames();
         if ($this->shouldFilter() && count($classNames)) {
@@ -147,6 +147,8 @@ class Lumberjack extends SiteTreeExtension
 
     /**
      * Checks if we're on a controller where we should filter. ie. Are we loading the SiteTree?
+     * NB: This only checks the current controller. See https://github.com/silverstripe/silverstripe-lumberjack/pull/60
+     * for a discussion around this.
      *
      * @return bool
      */


### PR DESCRIPTION
LumberJack::liveChildren() and LumberJack::stageChildren() should check if count(LumberJack::getExcludedSiteTreeClassNames()) > 0 to avoid an `InvalidArgumentException` exception being thrown by DataList::exclude().
