### PR TITLE
Fix excludeSiteTreeClassNames

### DIFF
--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -105,7 +105,8 @@ class Lumberjack extends SiteTreeExtension
     }
 
     /**
-     * Excludes any hidden owner subclasses
+     * Excludes any hidden owner subclasses. Note that the returned DataList will be a different
+     * instance from the original
      * @param DataList $list
      * @return DataList
      */

--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -105,7 +105,9 @@ class Lumberjack extends SiteTreeExtension
     }
 
     /**
-     * Excludes any hidden owner subclasses
+     * Excludes any hidden owner subclasses. Note that the returned DataList will be a different
+     * instance from the original.
+     *
      * @param DataList $list
      * @return DataList
      */

--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -107,6 +107,7 @@ class Lumberjack extends SiteTreeExtension
     /**
      * Excludes any hidden owner subclasses
      * @param DataList $list
+     * @return DataList
      */
     protected function excludeSiteTreeClassNames($list)
     {

--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -105,8 +105,7 @@ class Lumberjack extends SiteTreeExtension
     }
 
     /**
-     * Excludes any hidden owner subclasses. Note that the returned DataList will be a different
-     * instance from the original
+     * Excludes any hidden owner subclasses
      * @param DataList $list
      * @return DataList
      */

--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -100,7 +100,7 @@ class Lumberjack extends SiteTreeExtension
         }
 
         $this->owner->extend("augmentStageChildren", $staged, $showAll);
-        $this->excludeSiteTreeClassNames($staged);
+        $staged = $this->excludeSiteTreeClassNames($staged);
         return $staged;
     }
 
@@ -113,8 +113,9 @@ class Lumberjack extends SiteTreeExtension
         $classNames = $this->owner->getExcludedSiteTreeClassNames();
         if ($this->shouldFilter() && count($classNames)) {
             // Filter the SiteTree
-            $list->exclude('ClassName', $classNames);
+            $list = $list->exclude('ClassName', $classNames);
         }
+        return $list;
     }
 
     /**
@@ -156,7 +157,7 @@ class Lumberjack extends SiteTreeExtension
         if (!$showAll && DataObject::getSchema()->fieldSpec($this->owner, 'ShowInMenus')) {
             $children = $children->filter('ShowInMenus', 1);
         }
-        $this->excludeSiteTreeClassNames($children);
+        $children = $this->excludeSiteTreeClassNames($children);
 
         return $children;
     }


### PR DESCRIPTION
The new excludeSiteTreeClassNames() function doesn't return / modify any DataLists, hence the CMS SiteTree displays all children including those with `private static $show_in_sitetree = false;`

This patch fixes that.