### PR TITLE
Fix - an icons styles to SilverStripe font versions

### DIFF
--- a/css/lumberjack.css
+++ b/css/lumberjack.css
@@ -22,6 +22,10 @@
   margin-right: 6px;
 }
 /* line 27, ../scss/lumberjack.scss */
+.cms .gridfield-icon.published i {
+  color: #3fa142;
+}
+/* line 30, ../scss/lumberjack.scss */
 .cms .modified {
   margin-left: 5px;
   color: #7E7470;

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,11 +1,11 @@
 de:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Neuen {name} hinzufügen'
     AddMultipleOptions: 'Neuen hinzufügen'
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Als Entwurf am {date} gespeichert'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Als Entwurf am {date} gespeichert'
     Modified: Geändert
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Veröffentlicht am {date}'
+    Published: 'Veröffentlicht am {date}'
     StateTitle: Status
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: Unterseiten

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -3,9 +3,9 @@ de:
     Add: 'Neuen {name} hinzufügen'
     AddMultipleOptions: 'Neuen hinzufügen'
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Als Entwurf am {date} gespeichert'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Als Entwurf am {date} gespeichert'
     Modified: Geändert
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Veröffentlicht am {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Veröffentlicht am {date}'
     StateTitle: Status
   Lumberjack:
     TabTitle: Unterseiten

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,9 +3,9 @@ en:
     Add: 'Add new {name}'
     AddMultipleOptions: 'Add new'
   SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Saved as Draft on {date}'
+    Draft: 'Saved as Draft on {date}'
     Modified: Modified
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Published on {date}'
+    Published: 'Published on {date}'
     StateTitle: State
   SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: 'Child Pages'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -3,9 +3,9 @@ en:
     Add: 'Add new {name}'
     AddMultipleOptions: 'Add new'
   SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Saved as Draft on {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Saved as Draft on {date}'
     Modified: Modified
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Published on {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Published on {date}'
     StateTitle: State
   SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: 'Child Pages'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -1,11 +1,11 @@
 eo:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Enmeti novan {name}'
     AddMultipleOptions: 'Enmeti novan'
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> konserviĝis kiel malneto je {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'konserviĝis kiel malneto je {date}'
     Modified: Ŝanĝita
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> publikiĝis je {date}'
+    Published: 'publikiĝis je {date}'
     StateTitle: Stato
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: 'Idoj de paĝoj'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -3,9 +3,9 @@ eo:
     Add: 'Enmeti novan {name}'
     AddMultipleOptions: 'Enmeti novan'
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> konserviĝis kiel malneto je {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> konserviĝis kiel malneto je {date}'
     Modified: Ŝanĝita
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> publikiĝis je {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> publikiĝis je {date}'
     StateTitle: Stato
   Lumberjack:
     TabTitle: 'Idoj de paĝoj'

--- a/lang/fa_IR.yml
+++ b/lang/fa_IR.yml
@@ -1,9 +1,9 @@
 fa_IR:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'افزودن {name} جدید'
     AddMultipleOptions: 'افزودن جدید'
-  GridFieldSiteTreeState:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
     Modified: 'اصلاح شده'
     StateTitle: وضیعت
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: 'صفحات زیرین'

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -3,9 +3,9 @@ fi:
     Add: 'Lisää uusi {name}'
     AddMultipleOptions: 'Lisää uusi'
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Tallennettu luonnoksena {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Tallennettu luonnoksena {date}'
     Modified: Muokattu
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Julkaistu {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Julkaistu {date}'
     StateTitle: Tila
   Lumberjack:
     TabTitle: Alasivut

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -1,11 +1,11 @@
 fi:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Lisää uusi {name}'
     AddMultipleOptions: 'Lisää uusi'
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Tallennettu luonnoksena {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Tallennettu luonnoksena {date}'
     Modified: Muokattu
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Julkaistu {date}'
+    Published: 'Julkaistu {date}'
     StateTitle: Tila
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: Alasivut

--- a/lang/hr.yml
+++ b/lang/hr.yml
@@ -3,9 +3,9 @@ hr:
     Add: 'Dodaj novi {name}'
     AddMultipleOptions: 'Dodaj novi'
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Spremljeno kao Draft u {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Spremljeno kao Draft u {date}'
     Modified: Promjenjeno
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Objavljeno u {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Objavljeno u {date}'
     StateTitle: Stanje
   Lumberjack:
     TabTitle: Podstranice

--- a/lang/hr.yml
+++ b/lang/hr.yml
@@ -1,11 +1,11 @@
 hr:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Dodaj novi {name}'
     AddMultipleOptions: 'Dodaj novi'
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Spremljeno kao Draft u {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Spremljeno kao Draft u {date}'
     Modified: Promjenjeno
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Objavljeno u {date}'
+    Published: 'Objavljeno u {date}'
     StateTitle: Stanje
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: Podstranice

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -3,9 +3,9 @@ nl:
     Add: 'Voeg nieuwe {name} toe'
     AddMultipleOptions: 'Voeg nieuwe toe'
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Opgeslagen als concept op {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Opgeslagen als concept op {date}'
     Modified: Aangepast
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Gepubliceerd op {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Gepubliceerd op {date}'
     StateTitle: Status
   Lumberjack:
     TabTitle: 'Onderliggende pagina''s'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,11 +1,11 @@
 nl:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Voeg nieuwe {name} toe'
     AddMultipleOptions: 'Voeg nieuwe toe'
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Opgeslagen als concept op {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Opgeslagen als concept op {date}'
     Modified: Aangepast
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Gepubliceerd op {date}'
+    Published: 'Gepubliceerd op {date}'
     StateTitle: Status
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: 'Onderliggende pagina''s'

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -1,11 +1,11 @@
 ru:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Добавить {name}'
     AddMultipleOptions: Добавить
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Сохранено как черновик {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Сохранено как черновик {date}'
     Modified: Изменено
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Опубликовано {date}'
+    Published: 'Опубликовано {date}'
     StateTitle: Статус
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: Под-страницы

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -3,9 +3,9 @@ ru:
     Add: 'Добавить {name}'
     AddMultipleOptions: Добавить
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Сохранено как черновик {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Сохранено как черновик {date}'
     Modified: Изменено
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Опубликовано {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Опубликовано {date}'
     StateTitle: Статус
   Lumberjack:
     TabTitle: Под-страницы

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -1,11 +1,11 @@
 sk:
-  GridFieldSiteTreeAddNewButton:
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton::
     Add: 'Pridať {name}'
     AddMultipleOptions: Pridať
-  GridFieldSiteTreeState:
-    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Uložený ako koncept: {date}'
+  SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState:
+    Draft: 'Uložený ako koncept: {date}'
     Modified: zmenené
-    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Publikovaný: {date}'
+    Published: 'Publikovaný: {date}'
     StateTitle: Stav
-  Lumberjack:
+  SilverStripe\Lumberjack\Model\Lumberjack:
     TabTitle: Podstránky

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -3,9 +3,9 @@ sk:
     Add: 'Pridať {name}'
     AddMultipleOptions: Pridať
   GridFieldSiteTreeState:
-    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Uložený ako koncept: {date}'
+    Draft: '<i class="font-icon-pencil btn--icon-md"></i> Uložený ako koncept: {date}'
     Modified: zmenené
-    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Publikovaný: {date}'
+    Published: '<i class="font-icon-check-mark-circle btn--icon-md"></i> Publikovaný: {date}'
     StateTitle: Stav
   Lumberjack:
     TabTitle: Podstránky

--- a/scss/lumberjack.scss
+++ b/scss/lumberjack.scss
@@ -24,6 +24,9 @@
 		float: left;
 		margin-right: 6px;
 	}
+	.gridfield-icon.published i {
+		color: #3fa142;
+	}
 	.modified {
 		margin-left: 5px;
 		color: #7E7470;

--- a/src/Forms/GridFieldSiteTreeEditButton.php
+++ b/src/Forms/GridFieldSiteTreeEditButton.php
@@ -28,9 +28,10 @@ class GridFieldSiteTreeEditButton extends GridFieldEditButton
         // No permission checks - handled through GridFieldDetailForm
         // which can make the form readonly if no edit permissions are available.
 
-        $data = ArrayData::create(
-            ['Link' => $record->CMSEditLink()]
-        );
+        $data = ArrayData::create([
+              'Link' => $record->CMSEditLink(),
+              'ExtraClass' => $this->getExtraClass()
+        ]);
 
         return $data->renderWith(GridFieldEditButton::class);
     }

--- a/src/Forms/GridFieldSiteTreeState.php
+++ b/src/Forms/GridFieldSiteTreeState.php
@@ -42,14 +42,14 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider
             if ($record->hasMethod('isPublished')) {
                 $modifiedLabel = '';
                 if ($record->isModifiedOnStage) {
-                    $modifiedLabel = "<span class='modified'>" . _t(__CLASS__ . '.Modified', 'Modified') . '</span>';
+                    $modifiedLabel = '<span class="modified">' . _t(__CLASS__ . '.Modified', 'Modified') . '</span>';
                 }
 
                 $published = $record->isPublished();
                 if (!$published) {
                     return _t(
                         __CLASS__ . '.Draft',
-                        '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Saved as Draft on {date}',
+                        '<i class="font-icon-pencil btn--icon-md"></i> Saved as Draft on {date}',
                         'State for when a post is saved.',
                         array(
                             'date' => $record->dbObject('LastEdited')->Nice()
@@ -58,7 +58,7 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider
                 }
                 return _t(
                     __CLASS__ . '.Published',
-                    '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Published on {date}',
+                    '<i class="font-icon-check-mark-circle btn--icon-md"></i> Published on {date}',
                     'State for when a post is published.',
                     array(
                         'date' => $record->dbObject('LastEdited')->Nice()

--- a/src/Forms/GridFieldSiteTreeState.php
+++ b/src/Forms/GridFieldSiteTreeState.php
@@ -47,18 +47,18 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider
 
                 $published = $record->isPublished();
                 if (!$published) {
-                    return _t(
+                    return '<i class="font-icon-pencil btn--icon-md"></i>' .  _t(
                         __CLASS__ . '.Draft',
-                        '<i class="font-icon-pencil btn--icon-md"></i> Saved as Draft on {date}',
+                        'Saved as Draft on {date}',
                         'State for when a post is saved.',
                         array(
                             'date' => $record->dbObject('LastEdited')->Nice()
                         )
                     );
                 }
-                return _t(
+                return '<i class="font-icon-check-mark-circle btn--icon-md"></i>' . _t(
                     __CLASS__ . '.Published',
-                    '<i class="font-icon-check-mark-circle btn--icon-md"></i> Published on {date}',
+                    'Published on {date}',
                     'State for when a post is published.',
                     array(
                         'date' => $record->dbObject('LastEdited')->Nice()


### PR DESCRIPTION
This fixes #69 and  #71 

With this PR button Edit now looks like this:
![gridfield-lumberjack-edit-icon-after](https://user-images.githubusercontent.com/13778690/34907777-fa992fcc-f883-11e7-8c59-26702853f781.png)


And this is the full look _(with changes "State" icons)_:
![gridfield-lumberjack-whole-look-after-icons-update](https://user-images.githubusercontent.com/13778690/34909529-2243c680-f8a3-11e7-877c-b1fb682ca9e6.png)




