### PR TITLE
FIX Use class constant to point to correct stylesheet template

### DIFF
--- a/src/Forms/GridFieldSiteTreeAddNewButton.php
+++ b/src/Forms/GridFieldSiteTreeAddNewButton.php
@@ -75,7 +75,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton implements Gri
         } elseif (count($children) > 1) {
             $pageTypes = DropdownField::create('PageType', 'Page Type', $children, $parent->defaultChild());
             $pageTypes
-                ->setFieldHolderTemplate('GridFieldSiteTreeAddNewButton_holder')
+                ->setFieldHolderTemplate(__CLASS__ . '_holder')
                 ->addExtraClass('gridfield-dropdown no-change-track');
 
             $state->pageType = $parent->defaultChild();


### PR DESCRIPTION
There was a layout issue on a page with two allowed children, where a label was displayed oddly before the dropdown in the CMS. By pointing to the right template - which doesn't include the label - it fixes #72 