### PR TITLE
Add namespaces to sample code and separate classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![Build Status](https://travis-ci.org/silverstripe/silverstripe-lumberjack.svg?branch=master)](https://travis-ci.org/silverstripe/silverstripe-lumberjack)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/silverstripe-lumberjack/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-lumberjack/?branch=master)
 [![Code coverage](https://codecov.io/gh/silverstripe/silverstripe-lumberjack/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-lumberjack)
-[![Latest Stable Version](https://poser.pugx.org/silverstripe/lumberjack/v/stable)](https://packagist.org/packages/silverstripe/lumberjack)
-[![Latest Unstable Version](https://poser.pugx.org/silverstripe/lumberjack/v/unstable)](https://packagist.org/packages/silverstripe/lumberjack)
-[![License](https://poser.pugx.org/silverstripe/lumberjack/license)](https://packagist.org/packages/silverstripe/lumberjack)
 
 A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.
 
@@ -36,6 +33,8 @@ In this example we have a `NewsHolder` page which is the root of our news sectio
 ```php
 <?php
 
+namespace MyModule\PageTypes;
+
 use Page;
 use SilverStripe\Lumberjack\Model\Lumberjack;
 
@@ -46,16 +45,32 @@ class NewsHolder extends Page
     ];
 
     private static $allowed_children = [
-        'NewsArticle',
-        'NewsPage',
+        NewsArticle::class,
+        NewsPage::class,
     ];
 }
+```
+
+```php
+<?php
+
+namespace MyModule\PageTypes;
+
+use Page;
 
 class NewsArticle extends Page
 {
     private static $show_in_sitetree = false;
     private static $allowed_children = [];
 }
+```
+
+```php
+<?php
+
+namespace MyModule\PageTypes;
+
+use Page;
 
 class NewsPage extends Page
 {


### PR DESCRIPTION
This is to avoid any possible confusion with the CWP vendor module page types (the settings would need to be added within a config file in that case)