### PR TITLE
FIX Ensure extra CSS classes are used for GridField edit button

### DIFF
--- a/src/Forms/GridFieldConfig_Lumberjack.php
+++ b/src/Forms/GridFieldConfig_Lumberjack.php
@@ -10,9 +10,6 @@ use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
-use SilverStripe\Lumberjack\Forms\GridFieldSiteTreeAddNewButton;
-use SilverStripe\Lumberjack\Forms\GridFieldSiteTreeEditButton;
-use SilverStripe\Lumberjack\Forms\GridFieldSiteTreeState;
 
 /**
  * GridField config necessary for managing a SiteTree object.

--- a/src/Forms/GridFieldSiteTreeEditButton.php
+++ b/src/Forms/GridFieldSiteTreeEditButton.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\Lumberjack\Forms;
 
+use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 
 /**
@@ -10,11 +12,8 @@ use SilverStripe\View\ArrayData;
  *
  * Bypasses GridFieldDetailForm
  *
- * @package silverstripe
- * @subpackage lumberjack
- *
  * @author Michael Strong <mstrong@silverstripe.org>
-**/
+ **/
 class GridFieldSiteTreeEditButton extends GridFieldEditButton
 {
     /**
@@ -29,8 +28,8 @@ class GridFieldSiteTreeEditButton extends GridFieldEditButton
         // which can make the form readonly if no edit permissions are available.
 
         $data = ArrayData::create([
-              'Link' => $record->CMSEditLink(),
-              'ExtraClass' => $this->getExtraClass()
+            'Link' => $record->CMSEditLink(),
+            'ExtraClass' => $this->getExtraClass(),
         ]);
 
         return $data->renderWith(GridFieldEditButton::class);


### PR DESCRIPTION
~~We added ability for edit button classes to be configurable in https://github.com/silverstripe/silverstripe-framework/pull/7343. This class takes priority over the default edit button but doesn't allow the new ArrayData entry. This PR adds it (see `GridFieldEditButton::getColumnContent`).~~

*Edit:* This was actually already fixed in a409c377903db6a984fbf87c88be64870951e937. This PR now just tweaks some minor formatting =)

Fixes https://github.com/silverstripe/silverstripe-blog/issues/493