### PR TITLE
FIX hide_from_cms_tree can be applied to classes using Lumberjack

### DIFF
--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -91,7 +91,7 @@ class Lumberjack extends SiteTreeExtension
             $staged = $staged->exclude('ClassName', $hideFromHierarchy);
         }
 
-        if ($hideFromCMSTree && $this->showingCMSTree()) {
+        if ($hideFromCMSTree && $this->owner->showingCMSTree()) {
             $staged = $staged->exclude('ClassName', $hideFromCMSTree);
         }
 
@@ -153,7 +153,7 @@ class Lumberjack extends SiteTreeExtension
             $children = $children->exclude('ClassName', $hideFromHierarchy);
         }
 
-        if ($hideFromCMSTree && $this->showingCMSTree()) {
+        if ($hideFromCMSTree && $this->owner->showingCMSTree()) {
             $children = $children->exclude('ClassName', $hideFromCMSTree);
         }
 


### PR DESCRIPTION
`showingCMSTree` is a method defined on Hierarchy (extension) but isn't defined in Lumberjack. This PR fixes the reference to it so it will resolve correctly.

Fixes https://github.com/silverstripe/silverstripe-lumberjack/issues/83