### PR TITLE
FIX showingCMSTree() calls

### DIFF
--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -91,7 +91,7 @@ class Lumberjack extends SiteTreeExtension
             $staged = $staged->exclude('ClassName', $hideFromHierarchy);
         }
 
-        if ($hideFromCMSTree && $this->showingCMSTree()) {
+        if ($hideFromCMSTree && $this->owner->showingCMSTree()) {
             $staged = $staged->exclude('ClassName', $hideFromCMSTree);
         }
 
@@ -153,7 +153,7 @@ class Lumberjack extends SiteTreeExtension
             $children = $children->exclude('ClassName', $hideFromHierarchy);
         }
 
-        if ($hideFromCMSTree && $this->showingCMSTree()) {
+        if ($hideFromCMSTree && $this->owner->showingCMSTree()) {
             $children = $children->exclude('ClassName', $hideFromCMSTree);
         }
 


### PR DESCRIPTION
These appear to be referencing the extension $this rather than SiteTree/$this->owner, causing errors.