### PR TITLE
SS3: 301 Redirect (Permanent) for Add New button changed to 302 (Temporary)

### DIFF
--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -135,7 +135,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
             // Get the current record
             $record = SiteTree::get()->byId($controller->currentPageID());
             if ($record) {
-                $response->redirect(Director::absoluteBaseURL() . $record->CMSEditLink(), 301);
+                $response->redirect(Director::absoluteBaseURL() . $record->CMSEditLink(), 302);
             }
             return $response;
         }


### PR DESCRIPTION
This redirect being a 301 is causing issues with the browser caching the redirect request. Meaning rather than a new page always getting created it often ends up just redirecting to the last page to be created instead. Changing the redirect to a 302 resolves this bug.