### PR TITLE
FIX Ensure correct link is used when gridfield is readonly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "silverstripe-vendormodule",
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.3",
         "silverstripe/cms": "^5"
     },
     "require-dev": {

--- a/src/Forms/GridFieldSiteTreeViewButton.php
+++ b/src/Forms/GridFieldSiteTreeViewButton.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\Lumberjack\Forms;
+
+use SilverStripe\Forms\GridField\GridFieldViewButton;
+use SilverStripe\View\ArrayData;
+
+class GridFieldSiteTreeViewButton extends GridFieldViewButton
+{
+    public function getColumnContent($gridField, $record, $columnName)
+    {
+        if (!$record->canView()) {
+            return null;
+        }
+
+        $data = ArrayData::create([
+            'Link' => $record->CMSEditLink(),
+        ]);
+
+        return $data->renderWith(GridFieldViewButton::class);
+    }
+}

--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -10,8 +10,10 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldViewButton;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Lumberjack\Forms\GridFieldConfig_Lumberjack;
+use SilverStripe\Lumberjack\Forms\GridFieldSiteTreeViewButton;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -67,6 +69,15 @@ class Lumberjack extends SiteTreeExtension
                 $pages,
                 $this->getLumberjackGridFieldConfig()
             );
+
+            // Ensure correct link is used when gridfield is readonly
+            $readonlyComponents = $gridField->getReadonlyComponents();
+            $viewButtonIndex = array_search(GridFieldViewButton::class, $readonlyComponents);
+            if ($viewButtonIndex !== false) {
+                unset($readonlyComponents[$viewButtonIndex]);
+            }
+            $readonlyComponents[] = GridFieldSiteTreeViewButton::class;
+            $gridField->setReadonlyComponents($readonlyComponents);
 
             $tab = Tab::create('ChildPages', $this->getLumberjackTitle(), $gridField);
             $fields->insertAfter('Main', $tab);


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-framework/pull/11228

## Issue
-  https://github.com/silverstripe/silverstripe-lumberjack/issues/89