### PR TITLE
Add extension point to update the list of classnames excluded from site tree

### DIFF
--- a/src/Model/Lumberjack.php
+++ b/src/Model/Lumberjack.php
@@ -44,6 +44,8 @@ class Lumberjack extends SiteTreeExtension
             }
         }
 
+        $this->owner->extend('updateSiteTreeExcludedClassNames', $classes);
+
         return $classes;
     }
 


### PR DESCRIPTION
The extensions point could be used to further narrow down or expand the list of classes that should be excluded from the site tree for a given page type.

This can be used e.g. to provide CMS-based configurations of page exclusions rather than hardcoding this