### PR TITLE
MNT Remove branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,6 @@
         "squizlabs/php_codesniffer": "^3.0"
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        },
         "expose": [
             "css",
             "javascript"


### PR DESCRIPTION
Unit tests will probably fail.  This is simply to decouple the very out of date master branch from the default 2 branch.