### PR TITLE
FIX: clean up documentation and modernise code

### DIFF
--- a/src/Forms/GridFieldSiteTreeAddNewButton.php
+++ b/src/Forms/GridFieldSiteTreeAddNewButton.php
@@ -34,17 +34,17 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton implements Gri
      * Determine the list of classnames and titles allowed for a given parent object
      *
      * @param SiteTree $parent
-     * @return boolean
+     * @return array
      */
-    public function getAllowedChildren(SiteTree $parent = null)
+    public function getAllowedChildren(SiteTree $parent = null) : array
     {
         if (!$parent || !$parent->canAddChildren()) {
-            return array();
+            return [];
         }
 
         $nonHiddenPageTypes = SiteTree::page_type_classes();
         $allowedChildren = $parent->allowedChildren();
-        $children = array();
+        $children = [];
         foreach ($allowedChildren as $class) {
             if (Config::inst()->get($class, 'show_in_sitetree') === false) {
                 $instance = Injector::inst()->get($class);
@@ -59,7 +59,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton implements Gri
                 }
             }
         }
-        return $children;
+        return (array) $children;
     }
 
     public function getHTMLFragments($gridField)


### PR DESCRIPTION
Nothing special here, just a quick cleanup.  Do with it as you please (happy for someone else to commit properly). 

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green