### PR TITLE
FIX Allow use with earlier versions of silverstripe/framework

### DIFF
--- a/src/Forms/GridFieldSiteTreeAddNewButton.php
+++ b/src/Forms/GridFieldSiteTreeAddNewButton.php
@@ -66,7 +66,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton implements Gri
     {
         $state = $gridField->State->GridFieldSiteTreeAddNewButton;
 
-        $parent = SiteTree::get()->byId(Controller::curr()->currentRecordID());
+        $parent = SiteTree::get()->byId(Controller::curr()->currentPageID());
 
         if ($parent) {
             $state->currentPageID = $parent->ID;


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-lumberjack/issues/190

After this is merged and merged up I'll do another PR to CMS 6.0 to revert since the method will always be there