### PR TITLE
FIX Use new method name

### DIFF
--- a/src/Forms/GridFieldSiteTreeAddNewButton.php
+++ b/src/Forms/GridFieldSiteTreeAddNewButton.php
@@ -68,7 +68,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton implements Gri
     {
         $state = $gridField->State->GridFieldSiteTreeAddNewButton;
 
-        $parent = SiteTree::get()->byId(Controller::curr()->currentPageID());
+        $parent = SiteTree::get()->byId(Controller::curr()->currentRecordID());
 
         if ($parent) {
             $state->currentRecordID = $parent->ID;


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-lumberjack/issues/190

Essentially reverts https://github.com/silverstripe/silverstripe-lumberjack/pull/191/files which used a deprecated method name which was removed in CMS 6